### PR TITLE
[REFACTOR] 전자결재 결재라인 연동 및 문서함 리팩토링

### DIFF
--- a/src/components/eapproval/RetrieveModal.vue
+++ b/src/components/eapproval/RetrieveModal.vue
@@ -1,0 +1,115 @@
+<!-- 기안상신 모달 -->
+<template>
+  <div class="modal-overlay" @click.self="$emit('close')">
+    <div class="modal-content">
+      <!-- ◆ 모달 제목 -->
+        <div class="model-text">
+          <h3 class="modal-title">회수하기</h3>
+          <!-- ◆ 모달 본문 안내 문구 -->
+          <p class="modal-description">작성하신 기안을 회수하시겠습니까?</p>
+        </div>
+      <!-- ◆ 하단 버튼 영역 -->
+      <div class="approval-footer">
+        <div class="approval-btn-group">
+          <button class="modal-btn-cancel" @click="$emit('close')">취소</button>
+          <button class="modal-btn-submit" @click="submitApproval">확인</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const emit = defineEmits(['submit', 'close'])
+
+function submitApproval() {
+  emit('submit')
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 10px;
+  padding: 24px 32px;
+  width: 280px;
+  max-width: 90%;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  text-align: center;
+}
+
+.modal-title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 30px;
+}
+
+.modal-description {
+  font-size: 16px;
+  margin-bottom: 50px;
+  color: #333;
+}
+
+.approval-footer {
+  display: flex;
+  justify-content: center; /* 수평 가운데 정렬 */
+  align-items: center;
+  margin-top: 20px;
+}
+
+.approval-btn-group {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.modal-btn-submit {
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: inherit;
+  background-color: #00a8e8;
+  color: white;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 10px 30px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.modal-btn-submit:hover {
+  background-color: #fff;
+  color: #00a8e8;
+  border: 1px solid #00a8e8;
+}
+
+.modal-btn-cancel {
+  font-size: 14px;
+  font-weight: bold;
+  background-color: #D3D3D3;
+  color: #000;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 30px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s, box-shadow 0.2s;
+  box-sizing: border-box;
+}
+
+.modal-btn-cancel:hover {
+  background-color: #000;
+  color: #fff;
+}
+</style>

--- a/src/components/home/MyStatusBox.vue
+++ b/src/components/home/MyStatusBox.vue
@@ -18,21 +18,21 @@
     <div class="approval-wrapper">
       <div class="section-title-row">
         <div class="section-title">나의 결재 현황</div>
-        <div class="shortcut" @click="() => navigateTo('/draftdoc/approve')">↗</div>
+        <div class="shortcut" @click="() => navigateTo('/eapproval/approve')">↗</div>
       </div>
       <hr class="section-divider" />
       <div class="approval-list">
         <div class="approval-item">
           상신
-          <span class="count" @click="() => navigateTo('/draftdoc/mydraft', '상신')">{{ draftCount }}</span>
+          <span class="count" @click="() => navigateTo('/eapproval/mydraft', '상신')">{{ draftCount }}</span>
         </div>
         <div class="approval-item">
           결재대기
-          <span class="count" @click="() => navigateTo('/draftdoc/approve')">{{ approveWaitingCount }}</span>
+          <span class="count" @click="() => navigateTo('/eapproval/approve')">{{ approveWaitingCount }}</span>
         </div>
         <div class="approval-item">
           반려
-          <span class="count" @click="() => navigateTo('/draftdoc/mydraft', '반려')">{{ rejectCount }}</span>
+          <span class="count" @click="() => navigateTo('/eapproval/mydraft', '반려')">{{ rejectCount }}</span>
         </div>
       </div>
     </div>

--- a/src/components/sidebar/SubSidebar.vue
+++ b/src/components/sidebar/SubSidebar.vue
@@ -162,11 +162,11 @@
                 items: [
                     {
                         name: '기안양식함', 
-                        path: '/draftdoc/draftcreate'
+                        path: '/eapproval/temp'
                     },
                     {
                         name: '임시저장함', 
-                        path: '/draftdoc/temporarydoc'
+                        path: '/eapproval/temporarydoc'
                     },
                 ]
             },
@@ -174,19 +174,19 @@
                 items: [
                     {
                         name: '기안함', 
-                        path: '/draftdoc/mydraft'
+                        path: '/eapproval/mydraft'
                     },
                     {
                         name: '결재함', 
-                        path: '/draftdoc/approve'
+                        path: '/eapproval/approve'
                     },
                     {
                         name: '수신함', 
-                        path: '/draftdoc/inbox'
+                        path: '/eapproval/receiver'
                     },
                     {
                         name: '참조함', 
-                        path: '/draftdoc/reference'
+                        path: '/eapproval/reference'
                     },
                 ]
             },

--- a/src/pages/eapproval/ApprovalBoxPage.vue
+++ b/src/pages/eapproval/ApprovalBoxPage.vue
@@ -54,7 +54,7 @@ import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community'
 ModuleRegistry.registerModules([AllCommunityModule])
 
 // 상태 정의
-const tab = reactive({ value: '전체' })
+const tab = reactive({ value: '결재' })
 const search = reactive({ date: '', title: '' })
 const docs = ref([])
 const router = useRouter()  
@@ -181,7 +181,11 @@ function handleFormRowClick(params) {
   console.log('선택된 행:', params.data)
   const docId = params.data.docId
   // /drafts/8 같은 경로로 이동
-  router.push({ name: 'DraftDetail', params: { docId } })
+  router.push({
+    name: 'DraftDetail',
+    params: {docId},
+    query: { box: 'ApprovalBox' }
+})
 }
 </script>
 

--- a/src/pages/eapproval/DraftFormA.vue
+++ b/src/pages/eapproval/DraftFormA.vue
@@ -16,13 +16,13 @@
         <tbody>
           <tr>
             <td>기안부서</td>
-            <td><input v-model="form.department" type="text" /></td>
-            <td>직책</td>
-            <td><input v-model="form.position" type="text" /></td>
+            <td><input v-model="form.departmentName" type="text"  readonly /></td>
+            <td>직급</td>
+            <td><input v-model="form.rankName" type="text" readonly /></td>
           </tr>
           <tr>
             <td>기안자</td>
-            <td><input v-model="form.drafter" type="text" /></td>
+            <td><input v-model="form.drafter" type="text" readonly /></td>
             <td>기안일자</td>
             <!-- 화면에는 날짜만 보여주기 -->
             <td>
@@ -106,10 +106,9 @@
             <th>번호</th>
             <th>성명</th>
             <th>팀명</th>
-            <th>직책</th>
+            <th>직급</th>
             <th>상태</th>
             <th>종류</th>
-            <th>열람일시</th>
             <th>결재일시</th>
             <th>의견</th>
           </tr>
@@ -119,10 +118,9 @@
             <td>{{ index + 1 }}</td>
             <td>{{ line.name }}</td>
             <td>{{ line.team }}</td>
-            <td>{{ line.position }}</td>
+            <td>{{ line.rankName }}</td>
             <td>{{ line.status }}</td>
             <td>{{ line.type }}</td>
-            <td>{{ line.viewedAt }}</td>
             <td>{{ line.approvedAt }}</td>
             <td>{{ line.comment }}</td>
           </tr>
@@ -131,7 +129,6 @@
       <!-- ◆ 기안 내용 작성 영역 -->
       <div class="section-title">기안내용</div>
       <hr class="section-divider" />
-
       <!-- 제목, 첨부파일 테이블 -->
       <table class="file-table">
         <tbody>
@@ -218,8 +215,8 @@ export default {
   data() {
     return {
       form: {
-        department: "",
-        position: "",
+        departmentName: "",
+        rankName:"",
         drafter: "",
         draftDate: "",
         retentionPeriod: "",
@@ -264,6 +261,7 @@ export default {
     return this.form.draftDate?.slice(0, 10) || '';
   },
   methods: {
+    // ① 기안자 정보 불러오기
     async loadDrafterInfo() {
       try {
         const res = await fetch("http://localhost:8000/drafter/me", {
@@ -277,10 +275,10 @@ export default {
         }
         const data = await res.json();
         console.log("\u2705 기안자 정보:", data);
-        this.form.department = data.department;
+        this.form.departmentName = data.departmentName;
         this.form.drafter = data.name;
-        this.form.position = data.position;
-        await this.fetchAutoApprovalLine(data.employeeId);
+        this.form.rankName = data.rankName;
+        await this.fetchAutoApprovalLine(data.empId);
       } catch (e) {
         console.error("\u274C loadDrafterInfo 오류:", e);
         alert(e.message);
@@ -289,64 +287,49 @@ export default {
     updateDraftDate(val) {
       this.form.draftDate = val;
     },
-
-
-    async fetchAutoApprovalLine(employeeId) {
-      try {
-        const response = await axios.get("http://localhost:8000/approval-line", {
-          params: { employeeId, formId: 1 },
-          headers: { Authorization: `Bearer ${localStorage.getItem("token")}` }
-        });
-
-        this.approvalLines = response.data.flatMap(step =>
-          step.approverList.map(approver => {
-            const lineType = approver.lineType || "ACTUAL";
-            // ★ stepNo 가 1 이면 '기안', 2면 '미결', 그 이후면 '대기중'
-            let statusLabel;
-            if (step.stepNo === 1) {
-              statusLabel = "기안";
-            } else if (step.stepNo === 2) {
-              statusLabel = "미결";
-            } else {
-              statusLabel = "대기중";
-            }
-
-            // 타입 라벨 (실제/양식 or '결재' 구분)
-            const typeLabel = step.stepNo === 1
-              ? "기안"
-              : (approver.type === "INTERNAL" ? "결재" : approver.typeLabel || "");
-
-            const lineTypeLabel = lineType === "ACTUAL"
-              ? "실제 결재선"
-              : "양식 결재선";
-
-            return {
-              step:          step.stepNo,
-              name:          approver.employeeName,
-              employeeId:    approver.employeeId,
-              position:      approver.positionName,
-              team:          approver.teamName || "",
-              status:        statusLabel,  // ← 여기를 동적으로 변경
-              type:          typeLabel,
-              lineTypeLabel,
-              viewedAt:      null,
-              approvedAt:    null,
-              comment:       ""
-            };
-          })
-        );
-
-        console.log("📋 화면에 출력될 결재선:", this.approvalLines);
-
-      } catch (error) {
-        console.error("❌ 자동 결재선 조회 실패:", error);
+     // ② 자동 결재선 조회
+     async fetchAutoApprovalLine(empId) {
+  console.log("▶ fetchAutoApprovalLine 호출, empId =", empId);
+  try {
+    // response 객체에서 바로 data만 꺼내오기
+    const { data } = await axios.get(
+      "http://localhost:8000/approval-line",
+      {
+        params:     { employeeId: empId },
+        headers:    { Authorization: `Bearer ${localStorage.getItem("token")}` }
       }
+    );
+    // 꺼낸 data를 바로 map
+    this.approvalLines = data.map(item => ({
+      step:          item.step,
+      name:          item.employeeName,
+      employeeId:    item.employeeId,
+      rankName:      item.rankName || "",
+      role:          item.role || "",
+      team:          item.teamName     || "",
+      status:        "대기중",
+      type:          item.type,
+      lineTypeLabel: item.lineTypeLabel
+                   || (item.lineType === "ACTURE"
+                       ? "실제 결재선"
+                       : "양식 결재선"),
+      viewedAt:      null,
+      approvedAt:    null,
+      comment:       ""
+    }));
+    console.log("📋 화면에 출력될 결재선:", this.approvalLines);
 
-
+  } catch (error) {
+    console.error("❌ 자동 결재선 조회 실패:", error);
+  }
     },
+
+    // ③ 임시저장 모달 열기/닫기
     openApprovalModal() { this.showApprovalModal = true; },
     openReceiverModal() { this.showReceiverModal = true; },
     openReferenceModal() { this.showReferenceModal = true; },
+
+    // ④ 사용자 선택 모달 결과 처리
     onApprovalLineSubmit(lines) {
       console.log('🟢 수신된 커스텀 결재선:', lines);
       this.approvalLines = lines;
@@ -362,6 +345,8 @@ export default {
       this.showReferenceModal = false;
       this.form.reference = list.map(u => u.name).join(', ');
     },
+
+    // ⑤ 임시저장
     async confirmDraftSave() {
       const now = new Date();
       const draftData = {
@@ -379,38 +364,51 @@ export default {
         alert("임시저장 실패: " + (error.response?.data?.message || error.message));
       }
     },
+
+    // ⑥ 최종 상신하기: rankName·role 포함
     async confirmSubmit() {
       const now = new Date();
+      // (a) 전송할 데이터 형식 정의
       const submitData = {
-        title: this.form.title,
-        docContent: this.form.body,
-        retentionPeriod: this.form.retentionPeriod,
-        receiver: this.receiverList.map(u => u.id),
-        reference: this.referenceList.map(u => u.id),
-        formId: 1,
-        approvalLines: this.approvalLines.map((line, index) => ({
-          step: index + 1,
-          employeeId: line.employeeId,
-          position: line.position,
-          type: line.type,
+        title:            this.form.title,          // ⑥-1) 문서 제목
+        docContent:       this.form.body,           // ⑥-2) 본문 HTML
+        retentionPeriod:  this.form.retentionPeriod,// ⑥-3) 보존연한
+        receiver:         this.receiverList.map(u => u.id), // ⑥-4) 수신자 ID 리스트
+        reference:        this.referenceList.map(u => u.id),// ⑥-5) 참조자 ID 리스트
+        formId:           1,                        // ⑥-6) 양식 ID (고정)
+        approvalLines:    this.approvalLines.map((line, idx) => ({
+          step:       idx + 1,             // ⑥-7) 순번(step)
+          employeeId: line.employeeId,     // ⑥-8) 사원번호
+          position:   line.position,       // ⑥-9) 직책명
+          rankName:   line.rankName,       // ⑥-10) 직급명 추가
+          type:       line.type,           // ⑥-11) 결재 유형 코드
+          role:       line.role            // ⑥-12) document_box.role 추가
         }))
       };
+
        console.log("상신 데이터", JSON.stringify(submitData, null, 2));
-      try {
-        const res = await axios.post("http://localhost:8000/drafts/creation", submitData, {
+      
+      // (b) 서버에 POST 요청
+       try {
+        const res = await axios.post(
+          "http://localhost:8000/drafts/creation", submitData, {
           headers: {
             Authorization: `Bearer ${localStorage.getItem("token")}`
           }
         });
         const { docId } = res.data;
+
+        // (c) 성공 시 알림 및 이동
         alert(`상신 완료! 문서번호: ${docId}`);
         this.showSubmitModal = false;
-        this.$router.push(`/drafts/${docId}`);
+        this.$router.push({name: 'MyDraftBox'});
       } catch (error) {
         console.error("상신 실패", error);
         alert("상신 실패: " + (error.response?.data?.message || error.message));
       }
     },
+
+    // ⑦ 파일 업로드 처리
     handleFileUpload(event) {
       this.fileError = "";
       const file = event.target.files[0];
@@ -483,20 +481,18 @@ body, html {
 
 /* ✅ 메인 박스: 전체 레이아웃 래퍼 */
 .main-box {
-  background: #ffffff;
+  max-width: 1500px;
+  margin: 20px auto;
+  background: #fff;
+  padding: 18px;
+  box-shadow: 1px 1px 20px 1px rgba(0, 0, 0, 0.05);
   border-radius: 12px;
-  padding: 20px 32px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  margin: 24px;
-  max-width: 100%;
-  max-height: 1500px;
 }
 
 /* ✅ 내부 컨텐츠 컨테이너 */
 .container {
   font-family: Arial, sans-serif;
   max-width: 1350px;
-  max-height: 1500px;
   margin: 20px auto;
 }
 
@@ -887,7 +883,7 @@ textarea {
   font-size: 15px;               /* 글자 크기 */
   font-weight: bold;             /* 글자 굵게 */
   white-space: nowrap;           /* 줄바꿈 없이 한 줄로 표시 */
-  background-color: #f8f9fa;   
+  background-color: #f8f9fa;     /* 파란 배경 색 */
   text-align: center;            /* 텍스트 가운데 정렬 */
   display: flex;                 /* Flexbox 사용 */
   align-items: center;           /* 수직 가운데 정렬 */

--- a/src/pages/eapproval/DraftTempListPage.vue
+++ b/src/pages/eapproval/DraftTempListPage.vue
@@ -42,8 +42,8 @@ const formSearchQuery = ref('')
 const formsExpanded = ref(true)
 
 const registeredForms = ref([
-  { id: 1, name: '업무기안', retention: '5년', manager: '인사팀 이쁜펭', path: '/draft/formA' },
-  { id: 2, name: '외근신청서', retention: '5년', manager: '인사팀 이쁜펭', path: '/draft/formAB' },
+  { id: 1, name: '업무기안', retention: '5년', manager: '인사팀 이쁜펭', path: '/eapproval/formA' },
+  { id: 2, name: '외근신청서', retention: '5년', manager: '인사팀 이쁜펭', path: '/eapproval/formB' },
   { id: 3, name: '출장신청서', retention: '5년', manager: '인사팀 이쁜펭', path: '/form/business-trip' },
   { id: 4, name: '인사발령 결재요청서', retention: '5년', manager: '인사팀 이쁜펭', path: '/form/promotion' },
   { id: 5, name: '초과근무신청서', retention: '5년', manager: '인사팀 이쁜펭', path: '/form/overtime' },

--- a/src/pages/eapproval/ReceiverBoxPage.vue
+++ b/src/pages/eapproval/ReceiverBoxPage.vue
@@ -98,12 +98,25 @@ const filtered = docs.value.filter(doc => {
     return filtered.map((doc, idx) => ({ ...doc, no: filtered.length - idx }))
 })
 
+// function handleFormRowClick(params) {
+//     const row = docs.value.find(d => d.no === params.data.no)
+//     if (row && !row.readAt) {
+//         row.readAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
+//         row.status = '읽음'
+//     }
+// }
+
+
+// 6) 행 클릭 핸들러
 function handleFormRowClick(params) {
-    const row = docs.value.find(d => d.no === params.data.no)
-    if (row && !row.readAt) {
-        row.readAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
-        row.status = '읽음'
-    }
+  console.log('선택된 행:', params.data)
+  const docId = params.data.docId
+  // /drafts/8 같은 경로로 이동
+  router.push({
+    name: 'DraftDetail',
+    params: {docId},
+    query: { box: 'MyDraft' }
+  })
 }
 </script>
 

--- a/src/pages/eapproval/ReferenceBoxPage.vue
+++ b/src/pages/eapproval/ReferenceBoxPage.vue
@@ -105,6 +105,11 @@ function handleFormRowClick(params) {
         row.readAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
         row.status = '읽음'
     }
+    router.push({
+        name: 'DraftDetail',
+        params: {docId},
+        query: { box: 'ReferenceBox' }
+})
 }
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -168,63 +168,66 @@ const router = createRouter({
 
         // =============== 전자결재 ===============
 
-        // 기안 작성
+        // 기안 양식
         {
-            path: '/draftdoc/draftcreate',
-            component: () => import('@/pages/eapproval/DraftTemplateList.vue')
+            path: '/eapproval/temp',
+            name: 'DraftTempList',
+            component: () => import('@/pages/eapproval/DraftTempListPage.vue')
         },
-
+        // 상세페이지
+        {
+            path: '/eapproval/:docId',
+            name: 'DraftDetail',
+            component: () => import('@/pages/eapproval/DraftDetailPage.vue'),
+            props: true   
+        },
         // 임시저장함
         {
-            path: '/draftdoc/temporarydoc',
+            path: '/eapproval/temporarydoc',
             component: () => import('@/pages/eapproval/TemporaryDoc.vue')
         },
-
         // 기안함
         {
-            path: '/draftdoc/mydraft',
-            component: () => import('@/pages/eapproval/MyDraft.vue')
+            path: '/eapproval/mydraft',
+            name: 'MyDraftBox',
+            component: () => import('@/pages/eapproval/MyDraftBoxPage.vue')
         },
 
         // 결재함
         {
-            path: '/draftdoc/approve',
-            component: () => import('@/pages/eapproval/ApproveDoc.vue')
+            path: '/eapproval/approve',
+            name: 'ApprovalBox',
+            component: () => import('@/pages/eapproval/ApprovalBoxPage.vue')
         },
-        {
-            path: '/drafts/:docId',
-            name: 'DraftDetail',
-            component: () => import('@/pages/eapproval/DetailTest.vue'),
-            props: true   
-        },
-
         // 수신함 
         {
-            path: '/draftdoc/inbox',
-            component: () => import('@/pages/eapproval/InBox.vue')
+            path: '/eapproval/receiver',
+            name: 'ReceiverBox',
+            component: () => import('@/pages/eapproval/ReceiverBoxPage.vue')
         },
         // 참조함
         {
-            path: '/draftdoc/reference',
-            component: () => import('@/pages/eapproval/ReferenceDoc.vue')
+            path: '/eapproval/reference',
+            name: 'ReferenceBox',
+            component: () => import('@/pages/eapproval/ReferenceBoxPage.vue')
         },
 
         // 기안양식 (일반기안문서)
         {
-            path: '/draft/formA',
+            path: '/eapproval/formA',
             component: () => import('@/pages/eapproval/DraftFormA.vue')
         },
         // 기안양식 (외근신청서)
         {
-            path: '/draft/formB',
+            path: '/eapproval/formB',
             component: () => import('@/pages/eapproval/DraftFormB.vue')
         },        
          // 상세페이지
-        {
-            path: '/draft/:docId', // ← 기안 문서 ID에 따라 상세 조회
-            name: 'DraftDetail',
-            component: () => import('@/pages/eapproval/DetailTest.vue')        
-        },
+        // {
+        //     path: '/drafts/:docId', // ← 기안 문서 ID에 따라 상세 조회
+        //     name: 'DraftDetail',
+        //     component: () => import('@/pages/eapproval/DetailTest.vue')        
+        // },
         // =============== 급여 관리 ===============
 
         // 내  급여 명세서 조회


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 이 PR에서 작업한 내용을 간략히 설명해 주세요.
1. 기안함 데이터 포맷 형식 수정 
2. 기안작성/승인/반려 결재 후 기안함 내 로직처리 확인(상신, 반려 완료) , 회수 탭 백엔드 연동 진행중 
3. 결재라인 연동 확인 -> 추후 리팩토링 필요(결재 수동 지정 후 '직급' 데이터 처리 안됨)
4. 전자결재 라우터 리팩토링, 라우팅 구조 개편 -> 메뉴 및 더미에 반영
 
## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- #124  #80 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어 주세요. (예: 기술적 의사 결정, 고려사항 등)
- 추후 수신,참조, 첨부파일 로직과 통합 필요 (성준 작업본과 통합 예정)
- 기안 작성 시 새로 고침 후 본문 화면이 제대로 뜸..원인파악중..(아시는 분 공유 부탁드립니다)


 - 기안함
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/41772562-310d-469d-a659-07e98e690771" />

